### PR TITLE
Respect subtypes when publishing events to registered listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0]
+
+### Changed
+
+- The `SynchronousEventPublisher` will now invoke listeners when the published event is a subtype of the event they're
+interested in.
+
+## [0.2.0]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `SynchronousEventPublisher` will now invoke listeners when the published event is a subtype of the event they're
 interested in.
 
+### Added
+
+- Exception for event store implementations to throw when failing to append an event.
+
 ## [0.2.0]
 
 ### Added

--- a/src/Publishing/SynchronousEventPublisher.php
+++ b/src/Publishing/SynchronousEventPublisher.php
@@ -88,11 +88,11 @@ class SynchronousEventPublisher implements EventPublisher
 
     private function doPublish(Event $domainEvent) : void
     {
-        $class = get_class($domainEvent);
-
-        if (isset($this->listeners[$class])) {
-            foreach ($this->listeners[$class] as $listener) {
-                call_user_func($listener, $domainEvent);
+        foreach ($this->listeners as $class => $listeners) {
+            if (is_a($domainEvent, $class)) {
+                foreach ($listeners as $listener) {
+                    call_user_func($listener, $domainEvent);
+                }
             }
         }
 

--- a/src/Storage/Exception/EventStoreAppendException.php
+++ b/src/Storage/Exception/EventStoreAppendException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Krixon\DomainEvent\Storage\Exception;
+
+/**
+ * Thrown by an event store when it cannot appended a given event to the store.
+ */
+class EventStoreAppendException extends \RuntimeException implements EventStoreException
+{
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}


### PR DESCRIPTION
Previously, when publishing an event using the synchronous event publisher,
listeners were only invoked if they were registered to the exact same event.
This change results in listeners also being invoked if the event is a subtype
of the event they're registered to.